### PR TITLE
add dispatcher helper to package and small cleanups

### DIFF
--- a/MvvmLight.AppCompat/AppCompatDispatcherHelper.cs
+++ b/MvvmLight.AppCompat/AppCompatDispatcherHelper.cs
@@ -7,7 +7,7 @@ namespace JimBobBennett.MvvmLight.AppCompat
     ///     Helper class for dispatcher operations on the UI thread in Android.
     /// </summary>
     /// <remarks>Original code by Laurent Bugnion</remarks>
-    public static class AppcompatDispatcherHelper
+    public static class AppCompatDispatcherHelper
     {
         /// <summary>
         ///     Executes an action on the UI thread. If this method is called
@@ -52,7 +52,7 @@ namespace JimBobBennett.MvvmLight.AppCompat
         {
             if (AppCompatActivityBase.CurrentActivity == null)
             {
-                var error = new StringBuilder($"The {nameof(AppcompatDispatcherHelper)} cannot be called.");
+                var error = new StringBuilder($"The {nameof(AppCompatDispatcherHelper)} cannot be called.");
                 error.AppendLine();
                 error.Append($"Make sure that your main Activity derives from {nameof(AppCompatActivityBase)}.");
 

--- a/MvvmLight.AppCompat/AppCompatDispatcherHelper.cs
+++ b/MvvmLight.AppCompat/AppCompatDispatcherHelper.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Text;
+
+namespace JimBobBennett.MvvmLight.AppCompat
+{
+    /// <summary>
+    ///     Helper class for dispatcher operations on the UI thread in Android.
+    /// </summary>
+    /// <remarks>Original code by Laurent Bugnion</remarks>
+    public static class AppcompatDispatcherHelper
+    {
+        /// <summary>
+        ///     Executes an action on the UI thread. If this method is called
+        ///     from the UI thread, the action is executed immendiately. If the
+        ///     method is called from another thread, the action will be enqueued
+        ///     on the UI thread's dispatcher and executed asynchronously.
+        /// </summary>
+        /// <param name="action">
+        ///     The action that will be executed on the UI
+        ///     thread.
+        /// </param>
+        // ReSharper disable InconsistentNaming
+        public static void CheckBeginInvokeOnUI(Action action)
+            // ReSharper restore InconsistentNaming
+        {
+            if (action == null)
+            {
+                return;
+            }
+
+            CheckDispatcher();
+            AppCompatActivityBase.CurrentActivity.RunOnUiThread(action);
+        }
+
+        /// <summary>
+        ///     This method is only here for compatibility with
+        ///     other platforms but it doesn't do anything.
+        /// </summary>
+        public static void Initialize()
+        {
+        }
+
+        /// <summary>
+        ///     This method is only here for compatibility with
+        ///     other platforms but it doesn't do anything.
+        /// </summary>
+        public static void Reset()
+        {
+        }
+
+        private static void CheckDispatcher()
+        {
+            if (AppCompatActivityBase.CurrentActivity == null)
+            {
+                var error = new StringBuilder($"The {nameof(AppcompatDispatcherHelper)} cannot be called.");
+                error.AppendLine();
+                error.Append($"Make sure that your main Activity derives from {nameof(AppCompatActivityBase)}.");
+
+                throw new InvalidOperationException(error.ToString());
+            }
+        }
+    }
+}

--- a/MvvmLight.AppCompat/AppCompatNavigationService.cs
+++ b/MvvmLight.AppCompat/AppCompatNavigationService.cs
@@ -27,7 +27,7 @@ namespace JimBobBennett.MvvmLight.AppCompat
         
         public void NavigateTo(string pageKey, object parameter)
         {
-            AppCompatActivityBase.CurrentActivity.RunOnUiThread(() =>
+            AppcompatDispatcherHelper.CheckBeginInvokeOnUI(() =>
             {
                 if (AppCompatActivityBase.CurrentActivity == null)
                     throw new InvalidOperationException("No CurrentActivity found");

--- a/MvvmLight.AppCompat/AppCompatNavigationService.cs
+++ b/MvvmLight.AppCompat/AppCompatNavigationService.cs
@@ -27,7 +27,7 @@ namespace JimBobBennett.MvvmLight.AppCompat
         
         public void NavigateTo(string pageKey, object parameter)
         {
-            AppcompatDispatcherHelper.CheckBeginInvokeOnUI(() =>
+            AppCompatDispatcherHelper.CheckBeginInvokeOnUI(() =>
             {
                 if (AppCompatActivityBase.CurrentActivity == null)
                     throw new InvalidOperationException("No CurrentActivity found");

--- a/MvvmLight.AppCompat/JimBobBennett.MvvmLight.AppCompat.csproj
+++ b/MvvmLight.AppCompat/JimBobBennett.MvvmLight.AppCompat.csproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <Compile Include="AppCompatActivityBase.cs" />
     <Compile Include="AppCompatDialogService.cs" />
+    <Compile Include="AppCompatDispatcherHelper.cs" />
     <Compile Include="AppCompatNavigationService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/MvvmLight.AppCompat/JimBobBennett.MvvmLight.AppCompat.nuspec
+++ b/MvvmLight.AppCompat/JimBobBennett.MvvmLight.AppCompat.nuspec
@@ -4,7 +4,7 @@
     <id>JimBobBennett.MvvmLight.AppCompat</id>
     <version>$version$</version>
     <title>JimBobBennett MVVMLight AppCompat Helpers</title>
-    <authors>Jim Bennett</authors>
+    <authors>Jim Bennett, Samuel Debruyn, Laurent Bugnion</authors>
     <owners>Jim Bennett</owners>
     <projectUrl>https://github.com/jimbobbennett/JimBobBennett.MvvmLight.AppCompat</projectUrl>
     <iconUrl>http://github.com/jimbobbennett/JimLib/blob/master/JimLib/Jim-32x32.png</iconUrl>

--- a/MvvmLight.AppCompat/packages.config
+++ b/MvvmLight.AppCompat/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="monoandroid60" />
   <package id="MvvmLightLibs" version="5.2.0.0" targetFramework="monoandroid60" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="monoandroid50" />
   <package id="Xamarin.Android.Support.Design" version="23.1.1.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.v4" version="23.1.1.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.v7.AppCompat" version="23.1.1.0" targetFramework="monoandroid60" />


### PR DESCRIPTION
- Add `AppCompatDispatcherHelper` to the package
- Use the new helper instead of calling `RunOnUIThread`
- Credits to myself and Laurent Bugnion
- Remove dependency on `NuGet.CommandLine` as it does not seem to be required

Let me know if you want me to split them up.
